### PR TITLE
feat: Fail fast when docker is not installed

### DIFF
--- a/src/launcher.js
+++ b/src/launcher.js
@@ -13,7 +13,7 @@ class DockerLauncher {
         this.dockerLogs = null;
     }
 
-    onPrepare(config) {
+    async onPrepare(config) {
         this.logToStdout = config.logToStdout;
         this.dockerLogs = config.dockerLogs;
         this.watchMode = !!config.watch;
@@ -52,15 +52,15 @@ class DockerLauncher {
             });
         }
 
-        return this.docker.run()
-            .then(() => {
-                if (typeof onDockerReady === 'function') {
-                    onDockerReady();
-                }
-            })
-            .catch((err) => {
-                Logger.error(`Failed to run container: ${ err.message }`);
-            });
+        try {
+            await this.docker.run();
+            if (typeof onDockerReady === 'function') {
+                onDockerReady();
+            }
+        }
+        catch(err) {
+            Logger.error(`Failed to run container: ${ err.message }`);
+        }
     }
 
     onComplete() {
@@ -80,14 +80,13 @@ class DockerLauncher {
      * @param logFile
      * @private
      */
-    _redirectLogStream(logFile) {
+    async _redirectLogStream(logFile) {
         // ensure file & directory exists
-        return fs.ensureFile(logFile).then(() => {
-            const logStream = fs.createWriteStream(logFile, { flags: 'w' });
-
-            this.docker.process.stdout.pipe(logStream);
-            this.docker.process.stderr.pipe(logStream);
-        });
+        await fs.ensureFile(logFile);
+        
+        const logStream = fs.createWriteStream(logFile, { flags: 'w' });
+        this.docker.process.stdout.pipe(logStream);
+        this.docker.process.stderr.pipe(logStream);
     }
 }
 

--- a/src/launcher.js
+++ b/src/launcher.js
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import { SevereServiceError } from 'webdriverio';
 import Docker from './utils/docker';
 import getFilePath from './utils/getFilePath';
 import logger from '@wdio/logger';
@@ -58,7 +59,10 @@ class DockerLauncher {
                 onDockerReady();
             }
         }
-        catch(err) {
+        catch (err) {
+            if (err.code === 'ENOENT' && err.path === 'docker') {
+                throw new SevereServiceError('Docker was not found.');
+            }
             Logger.error(`Failed to run container: ${ err.message }`);
         }
     }

--- a/src/utils/docker.js
+++ b/src/utils/docker.js
@@ -80,49 +80,41 @@ class Docker extends EventEmitter {
             });
         }
 
+        await this._removeStaleContainer();
+
         try {
-            await this._removeStaleContainer();
-
-            try {
-                await this._isImagePresent();
-            } catch (_err) {
-                this.logger.warn('NOTE: Pulling image for the first time. Please be patient.');
-                return this._pullImage();
-            }
-
-            this.logger.info(`Launching docker image '${this.image}'`);
-            const process = await runProcess(this.dockerRunCommand);
-            this.process = process;
-            this.emit('processCreated');
-
-            if (this.debug) {
-                this.process.stdout.on('data', (data) => {
-                    this.logger.log(data.toString());
-                });
-
-                this.process.stderr.on('data', (data) => {
-                    this.logger.error(data.toString());
-                });
-
-                this.dockerEventsListener.once('container.start', (event) => {
-                    this.logger.info('Container started:', JSON.stringify(event, null, 4));
-                });
-
-                this.dockerEventsListener.once('container.stop', (event) => {
-                    this.logger.info('Container stopped:', JSON.stringify(event, null, 4));
-                });
-            }
-
-            await this._reportWhenDockerIsRunning();
-            this.logger.info('Docker container is ready');
-            return process;
-        } catch (err) {
-            if (err.code === 'ENOENT') {
-                return Promise.resolve();
-            }
-
-            throw err;
+            await this._isImagePresent();
+        } catch (_err) {
+            this.logger.warn('NOTE: Pulling image for the first time. Please be patient.');
+            return this._pullImage();
         }
+
+        this.logger.info(`Launching docker image '${this.image}'`);
+        const process = await runProcess(this.dockerRunCommand);
+        this.process = process;
+        this.emit('processCreated');
+
+        if (this.debug) {
+            this.process.stdout.on('data', (data) => {
+                this.logger.log(data.toString());
+            });
+
+            this.process.stderr.on('data', (data) => {
+                this.logger.error(data.toString());
+            });
+
+            this.dockerEventsListener.once('container.start', (event) => {
+                this.logger.info('Container started:', JSON.stringify(event, null, 4));
+            });
+
+            this.dockerEventsListener.once('container.stop', (event) => {
+                this.logger.info('Container stopped:', JSON.stringify(event, null, 4));
+            });
+        }
+
+        await this._reportWhenDockerIsRunning();
+        this.logger.info('Docker container is ready');
+        return process;
     }
 
     /**

--- a/src/utils/docker.js
+++ b/src/utils/docker.js
@@ -68,7 +68,7 @@ class Docker extends EventEmitter {
     /**
      * @return {Promise}
      */
-    run() {
+    async run() {
         this.logger.log(`Docker command: ${ this.dockerRunCommand.join(SPACE) }`);
         this.dockerEventsListener.connect({
             filter: `image=${ this.image }`
@@ -80,69 +80,64 @@ class Docker extends EventEmitter {
             });
         }
 
-        return this._removeStaleContainer()
-            .then(() => {
-                return this._isImagePresent()
-                    .catch(() => {
-                        this.logger.warn('NOTE: Pulling image for the first time. Please be patient.');
-                        return this._pullImage();
-                    });
-            })
-            .then(() => {
-                this.logger.info(`Launching docker image '${ this.image }'`);
-                return runProcess(this.dockerRunCommand);
-            })
-            .then(process => {
-                this.process = process;
-                this.emit('processCreated');
+        try {
+            await this._removeStaleContainer();
 
-                if (this.debug) {
-                    this.process.stdout.on('data', (data) => {
-                        this.logger.log(data.toString());
-                    });
+            try {
+                await this._isImagePresent();
+            } catch (_err) {
+                this.logger.warn('NOTE: Pulling image for the first time. Please be patient.');
+                return this._pullImage();
+            }
 
-                    this.process.stderr.on('data', (data) => {
-                        this.logger.error(data.toString());
-                    });
+            this.logger.info(`Launching docker image '${this.image}'`);
+            const process = await runProcess(this.dockerRunCommand);
+            this.process = process;
+            this.emit('processCreated');
 
-                    this.dockerEventsListener.once('container.start', (event) => {
-                        this.logger.info('Container started:', JSON.stringify(event, null, 4));
-                    });
+            if (this.debug) {
+                this.process.stdout.on('data', (data) => {
+                    this.logger.log(data.toString());
+                });
 
-                    this.dockerEventsListener.once('container.stop', (event) => {
-                        this.logger.info('Container stopped:', JSON.stringify(event, null, 4));
-                    });
-                }
+                this.process.stderr.on('data', (data) => {
+                    this.logger.error(data.toString());
+                });
 
-                return this._reportWhenDockerIsRunning()
-                    .then(() => {
-                        this.logger.info('Docker container is ready');
-                        return process;
-                    });
-            })
-            .catch((err) => {
-                if (err.code === 'ENOENT') {
-                    return Promise.resolve();
-                }
+                this.dockerEventsListener.once('container.start', (event) => {
+                    this.logger.info('Container started:', JSON.stringify(event, null, 4));
+                });
 
-                throw err;
-            });
+                this.dockerEventsListener.once('container.stop', (event) => {
+                    this.logger.info('Container stopped:', JSON.stringify(event, null, 4));
+                });
+            }
+
+            await this._reportWhenDockerIsRunning();
+            this.logger.info('Docker container is ready');
+            return process;
+        } catch (err) {
+            if (err.code === 'ENOENT') {
+                return Promise.resolve();
+            }
+
+            throw err;
+        }
     }
 
     /**
      * @return {Promise}
      */
-    stop() {
-        return this._removeStaleContainer()
-            .then(() => {
-                if (this.process) {
-                    this.process.kill();
-                    this.process = null;
-                }
+    async stop() {
+        await this._removeStaleContainer();
 
-                this.logger.info('Docker container has stopped');
-                this.dockerEventsListener.disconnect();
-            });
+        if (this.process) {
+            this.process.kill();
+            this.process = null;
+        }
+
+        this.logger.info('Docker container has stopped');
+        this.dockerEventsListener.disconnect();
     }
 
     /**
@@ -219,20 +214,20 @@ class Docker extends EventEmitter {
 
     /**
      * Removes any stale docker image
-     * @return {Promise}
+     * @return {Promise<void>}
      * @private
      */
-    _removeStaleContainer() {
-        return fs.readFile(this.cidfile)
-            .then((cid) => {
-                this.logger.info('Shutting down running container');
-                return Docker.stopContainer(cid).then(() => Docker.removeContainer(cid));
-            })
-            .catch(() => Promise.resolve())
-            .then(() => {
-                this.logger.info('Cleaning up CID files');
-                return fs.remove(this.cidfile);
-            });
+    async _removeStaleContainer() {
+        try {
+            const cid = await fs.readFile(this.cidfile);
+            this.logger.info('Shutting down running container');
+            await Docker.stopContainer(cid);
+            await Docker.removeContainer(cid);
+        }
+        catch (_err) {} // eslint-disable-line no-empty
+
+        this.logger.info('Cleaning up CID files');
+        await fs.remove(this.cidfile);
     }
 
     /**


### PR DESCRIPTION
## Description

- refactor: Use async/await instead of chained Promises
- feat: Throw a SevereServiceError when `docker` is not installed

## Checklist

- [ ] Unit/Integration test added (if applicable)
- [ ] Documentation added/updated (wiki or md)
- [X] Code style is consistent with the rest of the project

## Notes

- The top-level `catch` in `run()` was only being used to suppress the `ENOENT` error. We can pull that error handling up into the Service class where we call `run()`.
- This will close #133.
